### PR TITLE
Add basic Pixi.js slot game skeleton

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Pixi Slot Demo</title>
+  <style>
+    body {
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+    }
+    canvas {
+      border: 1px solid #ccc;
+    }
+    #spin-button {
+      margin-top: 20px;
+      padding: 10px 20px;
+      font-size: 16px;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="game-canvas"></canvas>
+  <button id="spin-button">Spin</button>
+  <script src="https://pixijs.download/release/pixi.min.js"></script>
+  <script src="slot.js"></script>
+</body>
+</html>

--- a/slot.js
+++ b/slot.js
@@ -1,0 +1,44 @@
+const app = new PIXI.Application({
+  view: document.getElementById('game-canvas'),
+  width: 480,
+  height: 270,
+  backgroundColor: 0x1099bb,
+});
+
+const REEL_WIDTH = 150;
+const SYMBOL_SIZE = 150;
+
+const reels = [];
+const textures = [];
+
+for (let i = 0; i < 6; i++) {
+  const g = new PIXI.Graphics();
+  g.beginFill(Math.random() * 0xffffff);
+  g.drawRect(0, 0, SYMBOL_SIZE, SYMBOL_SIZE);
+  g.endFill();
+  textures.push(app.renderer.generateTexture(g));
+}
+
+for (let i = 0; i < 3; i++) {
+  const reel = new PIXI.Container();
+  reel.x = i * REEL_WIDTH;
+
+  for (let j = 0; j < 3; j++) {
+    const symbol = new PIXI.Sprite(textures[Math.floor(Math.random() * textures.length)]);
+    symbol.y = j * SYMBOL_SIZE;
+    reel.addChild(symbol);
+  }
+
+  reels.push(reel);
+  app.stage.addChild(reel);
+}
+
+function spin() {
+  reels.forEach((reel) => {
+    reel.children.forEach((symbol) => {
+      symbol.texture = textures[Math.floor(Math.random() * textures.length)];
+    });
+  });
+}
+
+document.getElementById('spin-button').addEventListener('click', spin);


### PR DESCRIPTION
## Summary
- add a simple HTML page with a canvas and spin button
- implement a minimal PixiJS slot demo

## Testing
- `npm run lint` *(fails: No files matching the pattern "./src" were found)*

------
https://chatgpt.com/codex/tasks/task_e_684036380b48832c83d8ada45b9adfd8