### PR TITLE
Add reel timing config and skip control

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -5,4 +5,8 @@ export const MACHINE_CONFIG = {
   symbolSize: 150,
   extraSymbols: 2,
   spinSpeed: 10,
+  spinTime: 2000,      // base spin time in ms before reels start stopping
+  startDelay: 200,     // delay between reel starts in ms
+  stopDelay: 500,      // delay between stopping consecutive reels in ms
+  allowSkip: true,     // enable skip functionality
 };

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,21 @@ const app = new PIXI.Application({
 const slotMachine = new SlotMachine(app);
 app.stage.addChild(slotMachine);
 
-document.getElementById('spin-button').addEventListener('click', () => {
+const spinButton = document.getElementById('spin-button');
+
+slotMachine.onEnd = () => {
+  spinButton.textContent = 'Spin';
+};
+
+spinButton.addEventListener('click', () => {
+  if (slotMachine.spinning) {
+    if (MACHINE_CONFIG.allowSkip) {
+      slotMachine.skip();
+    }
+    return;
+  }
   slotMachine.start();
+  if (MACHINE_CONFIG.allowSkip) {
+    spinButton.textContent = 'Skip';
+  }
 });

--- a/src/slotMachine.js
+++ b/src/slotMachine.js
@@ -8,6 +8,10 @@ const {
   symbolSize: SYMBOL_SIZE,
   extraSymbols: EXTRA_SYMBOLS,
   spinSpeed: SPIN_SPEED,
+  spinTime: SPIN_TIME,
+  startDelay: START_DELAY,
+  stopDelay: STOP_DELAY,
+  allowSkip: ALLOW_SKIP,
 } = MACHINE_CONFIG;
 
 const SYMBOLS_PER_REEL = VISIBLE_ROWS + EXTRA_SYMBOLS;
@@ -59,6 +63,7 @@ export default class SlotMachine extends PIXI.Container {
     this.reels = [];
     this.reelMatrix = [];
     this.spinning = false;
+    this.onEnd = null;
 
     this._createReels();
     this.app.ticker.add((delta) => this.update(delta));
@@ -131,23 +136,51 @@ export default class SlotMachine extends PIXI.Container {
   }
 
   start() {
+    if (this.spinning) return;
     this.activeSet = Math.floor(Math.random() * this.reelSets.length);
     this.spinning = true;
+    this.startTimeouts = [];
+    this.stopTimeouts = [];
     this.reels.forEach((reel, i) => {
-      reel.speed = SPIN_SPEED;
-      reel.stripIndex = 0;
-      setTimeout(() => {
+      const startT = setTimeout(() => {
+        reel.speed = SPIN_SPEED;
+        reel.stripIndex = 0;
+      }, i * START_DELAY);
+      this.startTimeouts.push(startT);
+
+      const stopT = setTimeout(() => {
         this.stopReel(reel, i);
         if (i === this.reels.length - 1) {
           this.spinning = false;
+          if (this.onEnd) this.onEnd();
           console.log('Reel matrix:', this.reelMatrix);
         }
-      }, 1000 + i * 500);
+      }, SPIN_TIME + i * STOP_DELAY);
+      this.stopTimeouts.push(stopT);
     });
   }
 
   stop() {
     this.reels.forEach((reel, i) => this.stopReel(reel, i));
     this.spinning = false;
+  }
+
+  skip() {
+    if (!this.spinning || !ALLOW_SKIP) return;
+    if (this.startTimeouts) {
+      this.startTimeouts.forEach((t) => clearTimeout(t));
+      this.startTimeouts = [];
+    }
+    if (this.stopTimeouts) {
+      this.stopTimeouts.forEach((t) => clearTimeout(t));
+      this.stopTimeouts = [];
+    }
+    this.reels.forEach((reel, i) => {
+      reel.speed = 0;
+      this.stopReel(reel, i);
+    });
+    this.spinning = false;
+    if (this.onEnd) this.onEnd();
+    console.log('Reel matrix:', this.reelMatrix);
   }
 }


### PR DESCRIPTION
## Summary
- allow configuration of spin duration, start/stop delays and skip toggle
- launch reels sequentially and stop sequentially using config values
- implement skip button behaviour

## Testing
- `npm run lint`
- `npm run build` *(fails: webpack not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68404bf1a5e8832c97f866df76646ab6