### PR TITLE
Fix skip to reveal final symbols

### DIFF
--- a/src/slotMachine.js
+++ b/src/slotMachine.js
@@ -175,8 +175,17 @@ export default class SlotMachine extends PIXI.Container {
       this.stopTimeouts.forEach((t) => clearTimeout(t));
       this.stopTimeouts = [];
     }
+    const loopsPerMs = (SPIN_SPEED * 60) / (SYMBOL_SIZE * 1000);
     this.reels.forEach((reel, i) => {
-      reel.speed = 0;
+      const strip = this.reelSets[this.activeSet][i];
+      const loops = Math.round((SPIN_TIME + i * STOP_DELAY) * loopsPerMs);
+      reel.symbols.forEach((s, idx) => {
+        const offset = loops + idx - EXTRA_SYMBOLS;
+        const id = strip[offset % strip.length];
+        s.texture = this.textures[id];
+        s._id = id;
+        s.y = (idx - EXTRA_SYMBOLS) * SYMBOL_SIZE;
+      });
       this.stopReel(reel, i);
     });
     this.spinning = false;


### PR DESCRIPTION
## Summary
- handle skip by force-updating reels to their final positions

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68404f14f500832cb3f1f27f5207008e