### PR TITLE
Use animation-frame timing for slot machine

### DIFF
--- a/src/rafTimers.js
+++ b/src/rafTimers.js
@@ -1,0 +1,54 @@
+class RafScheduler {
+  constructor() {
+    this.timers = [];
+    this.running = false;
+    this.last = 0;
+    this._tick = this._tick.bind(this);
+  }
+
+  _tick(now) {
+    const delta = now - this.last;
+    this.last = now;
+    for (let i = this.timers.length - 1; i >= 0; i -= 1) {
+      const t = this.timers[i];
+      if (t.cancelled) {
+        this.timers.splice(i, 1);
+        continue;
+      }
+      t.remaining -= delta;
+      if (t.remaining <= 0) {
+        this.timers.splice(i, 1);
+        t.cb();
+      }
+    }
+    if (this.timers.length > 0) {
+      requestAnimationFrame(this._tick);
+    } else {
+      this.running = false;
+    }
+  }
+
+  start() {
+    if (!this.running) {
+      this.running = true;
+      this.last = performance.now();
+      requestAnimationFrame(this._tick);
+    }
+  }
+
+  setTimeout(cb, delay) {
+    const timer = { cb, remaining: delay, cancelled: false };
+    this.timers.push(timer);
+    this.start();
+    return timer;
+  }
+
+  clearTimeout(timer) {
+    if (timer) timer.cancelled = true;
+  }
+}
+
+const scheduler = new RafScheduler();
+export const rafSetTimeout = (cb, delay) => scheduler.setTimeout(cb, delay);
+export const rafClearTimeout = (timer) => scheduler.clearTimeout(timer);
+

--- a/src/slotMachine.js
+++ b/src/slotMachine.js
@@ -1,5 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { MACHINE_CONFIG } from './config.js';
+import { rafSetTimeout, rafClearTimeout } from './rafTimers.js';
 
 const {
   reels: REEL_COUNT,
@@ -142,13 +143,13 @@ export default class SlotMachine extends PIXI.Container {
     this.startTimeouts = [];
     this.stopTimeouts = [];
     this.reels.forEach((reel, i) => {
-      const startT = setTimeout(() => {
+      const startT = rafSetTimeout(() => {
         reel.speed = SPIN_SPEED;
         reel.stripIndex = 0;
       }, i * START_DELAY);
       this.startTimeouts.push(startT);
 
-      const stopT = setTimeout(() => {
+      const stopT = rafSetTimeout(() => {
         this.stopReel(reel, i);
         if (i === this.reels.length - 1) {
           this.spinning = false;
@@ -168,11 +169,11 @@ export default class SlotMachine extends PIXI.Container {
   skip() {
     if (!this.spinning || !ALLOW_SKIP) return;
     if (this.startTimeouts) {
-      this.startTimeouts.forEach((t) => clearTimeout(t));
+      this.startTimeouts.forEach((t) => rafClearTimeout(t));
       this.startTimeouts = [];
     }
     if (this.stopTimeouts) {
-      this.stopTimeouts.forEach((t) => clearTimeout(t));
+      this.stopTimeouts.forEach((t) => rafClearTimeout(t));
       this.stopTimeouts = [];
     }
     const loopsPerMs = (SPIN_SPEED * 60) / (SYMBOL_SIZE * 1000);


### PR DESCRIPTION
## Summary
- replace `setTimeout` usage with RAF-based scheduler
- drive reel timers from a single requestAnimationFrame loop

## Testing
- `npm run lint`
- `npm run build` *(fails: `webpack` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684059b77a98832ca09718d04a99f0c5